### PR TITLE
Update pollardsrho.c

### DIFF
--- a/pollardsrho.c
+++ b/pollardsrho.c
@@ -1,8 +1,8 @@
-#include <gmp.h>
 #include <math.h>
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <gmp.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>


### PR DESCRIPTION
Changing the include order to avoid "implicit declaration of function warning"

I had a problem to compile the code and searching about it I found this[1] message about
the correct order of include between gmp.h and stdio.h

So I just changed the order and the compilation happened without any problem.

[1]https://gmplib.org/list-archives/gmp-bugs/2019-April/004541.html